### PR TITLE
Allow newer versions of pydicom than 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 Referenced versions in headers are tagged on Github, in parentheses are for pypi.
 
 ## [vxx](https://github.com/pydicom/deid/tree/master) (master)
+ - Allowing pydicom >= 1.2.1 (0.1.38)
  - removing matplotlib version requirement (0.1.37)
  - Matplotlib dependency >= 2.1.2 (0.1.36)
  - Adding black formatting, tests run in GitHub actions (0.1.35)

--- a/deid/version.py
+++ b/deid/version.py
@@ -33,6 +33,6 @@ LICENSE = "LICENSE"
 
 INSTALL_REQUIRES = (
     ("matplotlib", {"min_version": None}),
-    ("pydicom", {"exact_version": "1.2.1"}),
+    ("pydicom", {"min_version": "1.2.1"}),
     ("python-dateutil", {"min_version": None}),
 )


### PR DESCRIPTION
I've encountered one more version conflict, this time with `pydicom`. I'm sorry I didn't see this before you went through the hazzle of making the previous releases, but my tool simply did not allow me to find that.

Is there any particular reason for requiring exactly version 1.2.1? I've investigated pydicom's changelog and cannot see any obvious breaking changes in the newer versions.

I've also verified that `ADD`, `REPLACE`, `REMOVE` and `JITTER` behave the same as with the current latest release.

Related issues: #111, #109

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] My code follows the style guidelines of this project